### PR TITLE
Fix config value to match config file

### DIFF
--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -20,7 +20,7 @@ class ElasticApmServiceProvider extends ServiceProvider
             __DIR__.'/../../config/elastic-apm.php' => config_path('elastic-apm.php'),
         ], 'config');
 
-        if (config('elastic-apm.enabled') === true && config('elastic-apm.spans.querylog.enabled') !== false) {
+        if (config('elastic-apm.active') === true && config('elastic-apm.spans.querylog.enabled') !== false) {
             $this->listenForQueries();
         }
     }


### PR DESCRIPTION
The default config file names a key called 'active', not 'enabled'.