### PR TITLE
Fix active config option

### DIFF
--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -44,7 +44,7 @@ class ElasticApmServiceProvider extends ServiceProvider
                         'framework' => 'Laravel',
                         'frameworkVersion' => app()->version(),
                     ],
-                    ['active' => config('elastic.active')],
+                    ['active' => config('elastic-apm.active')],
                     config('elastic-apm.app'),
                     config('elastic-apm.env'),
                     config('elastic-apm.server')


### PR DESCRIPTION
The config name for activating the package was incorrectly named when doing the config merge, therefore it was not possible to disable.
Also fixes #23 