### PR TITLE
33 address running tests and laravel start time

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,13 @@ The following environment variables are supported in the default configuration:
 You may also publish the `elastic-apm.php` configuration file to change additional settings:
 
 ```bash
-php artisan vendor:publish --tag=config --provider="PhilKra\ElasticApmLaravel\Providers\ElasticApmService
-Provider"
+php artisan vendor:publish --tag=config
 ```
 
 Once published, open the `config/elastic-apm.php` file and review the various settings.
+
+### Laravel Test Setup
+
+Laravel provides classes to support running unit and feature tests with PHPUnit. In most cases, you will want to explicitly disable APM during testing since it is enabled by default. Refer to the Laravel documentation for more information (https://laravel.com/docs/5.7/testing).
+
+Because the APM agent checks it's active status using a strict boolean type, you must ensure your `APM_ACTIVE` value is a boolean `false` rather than simply a falsy value. The best way to accomplish this is to create an `.env.testing` file and include `APM_ACTIVE=false`, along with any other environment settings required for your tests. This file should be safe to include in your SCM.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
       "illuminate/http":"5.5.x|5.6.x|5.7.x",
       "illuminate/routing":"5.5.x|5.6.x|5.7.x",
       "illuminate/support":"5.5.x|5.6.x|5.7.x",
-      "philkra/elastic-apm-php-agent":"dev-48-allow-explicit-timer-start",
+      "philkra/elastic-apm-php-agent":">=6.5.3",
       "ramsey/uuid":"^3.0"
    },
    "require-dev":{  

--- a/composer.json
+++ b/composer.json
@@ -55,11 +55,5 @@
          "name":"George Boot",
          "email":"george@entryninja.com"
       }
-   ],
-   "repositories": [
-      {
-         "type": "vcs",
-         "url": "git@github.com:MiamiOH/elastic-apm-php-agent.git"
-      }
    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,4 @@
-{  
+{
    "name":"philkra/elastic-apm-laravel",
    "keywords":[  
       "laravel",
@@ -16,7 +16,7 @@
       "illuminate/http":"5.5.x|5.6.x|5.7.x",
       "illuminate/routing":"5.5.x|5.6.x|5.7.x",
       "illuminate/support":"5.5.x|5.6.x|5.7.x",
-      "philkra/elastic-apm-php-agent":"6.*.*",
+      "philkra/elastic-apm-php-agent":"dev-48-allow-explicit-timer-start",
       "ramsey/uuid":"^3.0"
    },
    "require-dev":{  
@@ -54,6 +54,12 @@
       {  
          "name":"George Boot",
          "email":"george@entryninja.com"
+      }
+   ],
+   "repositories": [
+      {
+         "type": "vcs",
+         "url": "git@github.com:MiamiOH/elastic-apm-php-agent.git"
       }
    ]
 }

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -12,14 +12,19 @@ class RecordTransaction
      * @var \PhilKra\Agent
      */
     protected $agent;
+    /**
+     * @var float
+     */
+    private $startTime;
 
     /**
      * RecordTransaction constructor.
      * @param Agent $agent
      */
-    public function __construct(Agent $agent)
+    public function __construct(Agent $agent, float $startTime)
     {
         $this->agent = $agent;
+        $this->startTime = $startTime;
     }
 
     /**
@@ -31,7 +36,9 @@ class RecordTransaction
     public function handle($request, Closure $next)
     {
         $transaction = $this->agent->startTransaction(
-            $this->getTransactionName($request)
+            $this->getTransactionName($request),
+            [],
+            $this->startTime
         );
 
         // await the outcome
@@ -60,9 +67,7 @@ class RecordTransaction
             $transaction->setTransactionName($this->getRouteUriTransactionName($request));
         }
 
-        $transaction->stop(
-            $this->getDuration(LARAVEL_START)
-        );
+        $transaction->stop();
 
         return $response;
     }

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -123,19 +123,6 @@ class RecordTransaction
     }
 
     /**
-     * @param $start
-     *
-     * @return float
-     */
-    protected function getDuration($start): float
-    {
-        $diff = microtime(true) - $start;
-        $corrected = $diff * 1000; // convert to miliseconds
-
-        return round($corrected, 3);
-    }
-
-    /**
      * @param array $headers
      *
      * @return array

--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -5,6 +5,7 @@ namespace PhilKra\ElasticApmLaravel\Middleware;
 use Closure;
 use Illuminate\Support\Facades\Log;
 use PhilKra\Agent;
+use PhilKra\Helper\Timer;
 
 class RecordTransaction
 {
@@ -13,18 +14,18 @@ class RecordTransaction
      */
     protected $agent;
     /**
-     * @var float
+     * @var Timer
      */
-    private $startTime;
+    private $timer;
 
     /**
      * RecordTransaction constructor.
      * @param Agent $agent
      */
-    public function __construct(Agent $agent, float $startTime)
+    public function __construct(Agent $agent, Timer $timer)
     {
         $this->agent = $agent;
-        $this->startTime = $startTime;
+        $this->timer = $timer;
     }
 
     /**
@@ -36,9 +37,7 @@ class RecordTransaction
     public function handle($request, Closure $next)
     {
         $transaction = $this->agent->startTransaction(
-            $this->getTransactionName($request),
-            [],
-            $this->startTime
+            $this->getTransactionName($request)
         );
 
         // await the outcome
@@ -67,7 +66,7 @@ class RecordTransaction
             $transaction->setTransactionName($this->getRouteUriTransactionName($request));
         }
 
-        $transaction->stop();
+        $transaction->stop($this->timer->getElapsedInMilliseconds());
 
         return $response;
     }

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -11,6 +11,11 @@ use PhilKra\Helper\Timer;
 
 class ElasticApmServiceProvider extends ServiceProvider
 {
+    /** @var float */
+    private $startTime;
+    /** @var Timer */
+    private $timer;
+
     /**
      * Bootstrap the application services.
      *
@@ -57,9 +62,10 @@ class ElasticApmServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->when('PhilKra\ElasticApmLaravel\Middleware\RecordTransaction')
-            ->needs('$startTime')
-            ->give($this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true));
+        $this->startTime = $this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true);
+        $this->timer = new Timer($this->startTime);
+
+        $this->app->instance(Timer::class, $this->timer);
 
         $this->app->alias(Agent::class, 'elastic-apm');
         $this->app->instance('query-log', collect([]));
@@ -167,7 +173,7 @@ class ElasticApmServiceProvider extends ServiceProvider
             $query = [
                 'name' => 'Eloquent Query',
                 'type' => 'db.mysql.query',
-                'start' => round((microtime(true) - $query->time / 1000 - LARAVEL_START) * 1000, 3),
+                'start' => round((microtime(true) - $query->time / 1000 - $this->startTime) * 1000, 3),
                 // calculate start time from duration
                 'duration' => round($query->time, 3),
                 'stacktrace' => $stackTrace,

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use PhilKra\Agent;
 use PhilKra\ElasticApmLaravel\Contracts\VersionResolver;
+use PhilKra\Helper\Timer;
 
 class ElasticApmServiceProvider extends ServiceProvider
 {
@@ -55,6 +56,10 @@ class ElasticApmServiceProvider extends ServiceProvider
                 )
             );
         });
+
+        $this->app->when('PhilKra\ElasticApmLaravel\Middleware\RecordTransaction')
+            ->needs('$startTime')
+            ->give($this->app['request']->server('REQUEST_TIME_FLOAT') ?? microtime(true));
 
         $this->app->alias(Agent::class, 'elastic-apm');
         $this->app->instance('query-log', collect([]));


### PR DESCRIPTION
This is a draft PR so we can discuss this proposed change.

I am concerned about the use of the `LARAVEL_START` constant. Not only does this cause problems in feature test scenarios, but that constant does not appear to be explicitly exposed by the framework in a sustainable way. Additional, this module reimplements timing and duration calculations for use in the APM transaction which could be provided with an existing Timer class.

This change does require an update to the elastic-apm-php-agent dependency.

The updated Timer class can accept an explicit start time. The PHP provided `REQUEST_TIME_FLOAT` appears to be the appropriate source for that start time. The popular Laravel DebugBar plugin has stopped using LARAVEL_START in favor of this approach.

The service provider will register a new Timer object and ensure it is correctly initialized. The service provider will also set a private start time member to the same value for use in query timing.

I believe this change is consistent with the Laravel framework conventions and consolidates APM related timing calculations.