### PR TITLE
Allow config of environment via env

### DIFF
--- a/config/elastic-apm.php
+++ b/config/elastic-apm.php
@@ -30,6 +30,9 @@ return [
 
         // API version of the apm agent you connect to
         'apmVersion'    => env('APM_APIVERSION', 'v1'),
+        
+        // Application environment
+        'environment'   => env('APM_ENVIRONMENT', 'development'),
 
         // Hostname of the system the agent is running on.
         'hostname'      => gethostname(),


### PR DESCRIPTION
The pure php library passes development for the environment by default. This allows you to override that with an env var instead of forcing you to export the config.