### PR TITLE
Allow config of environment

### DIFF
--- a/config/elastic-apm.php
+++ b/config/elastic-apm.php
@@ -14,8 +14,10 @@ return [
 
     'env' => [
         // whitelist environment variables OR send everything
-        'env' => ['DOCUMENT_ROOT', 'REMOTE_ADDR']
+        'env' => ['DOCUMENT_ROOT', 'REMOTE_ADDR'],
         //'env' => []
+        // Application environment
+        'environment'   => env('APM_ENVIRONMENT', 'development'),
     ],
 
     // GuzzleHttp\Client options (http://docs.guzzlephp.org/en/stable/request-options.html#request-options)


### PR DESCRIPTION
The pure php library passes development for the environment by default. This allows you to override that with and env var instead of forcing you to export the config.