### PR TITLE
support additional fields for user context

### DIFF
--- a/src/Middleware/RecordTransaction.php
+++ b/src/Middleware/RecordTransaction.php
@@ -50,9 +50,13 @@ class RecordTransaction
             'headers' => $this->formatHeaders($response->headers->all()),
         ]);
 
+        $user = $request->user();
         $transaction->setUserContext([
-            'id' => optional($request->user())->id,
-            'email' => optional($request->user())->email,
+            'id' => optional($user)->id,
+            'email' => optional($user)->email,
+            'username' => optional($user)->user_name,
+            'ip' => $request->ip(),
+            'user-agent' => $request->userAgent(),
         ]);
 
         $transaction->setMeta([


### PR DESCRIPTION
We needed to be able to search requests for ip address and I noticed that the apm server by default is set up to receive and index these fields in the user context so I added them to the middleware.

![image](https://user-images.githubusercontent.com/382230/62877239-9a671600-bcf4-11e9-9ce5-861b4fbd0a43.png)

![image](https://user-images.githubusercontent.com/382230/62877284-b10d6d00-bcf4-11e9-98f6-d4b1f7012a07.png)
