### PR TITLE
Fix compatible version of dep elastic-apm-php-agent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
       "illuminate/http":"5.5.x|5.6.x|5.7.x|5.8.x",
       "illuminate/routing":"5.5.x|5.6.x|5.7.x|5.8.x",
       "illuminate/support":"5.5.x|5.6.x|5.7.x|5.8.x",
-      "philkra/elastic-apm-php-agent":">=6.5.3",
+      "philkra/elastic-apm-php-agent":"^6.5.3",
       "ramsey/uuid":"^3.0"
    },
    "require-dev":{  


### PR DESCRIPTION
I created a release branch from the tag v5.8.2 and fixed the version of the package `elastic-apm-php-agent`. I suggest to add the same branch in your project and to create a new patch release to keep compatibility.

Fixes #66 