### PR TITLE
Laravel 6 support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2019-09-30 (6.0.1) devngl
+    * Laravel 6 support.
+
 2019-02-27 (5.7.6) mpetrunic
     * Fix Lumen compatibility issues
 

--- a/src/Providers/ElasticApmServiceProvider.php
+++ b/src/Providers/ElasticApmServiceProvider.php
@@ -104,7 +104,7 @@ class ElasticApmServiceProvider extends ServiceProvider
     protected function stripVendorTraces(Collection $stackTrace): Collection
     {
         return collect($stackTrace)->filter(function ($trace) {
-            return !Str::startsWith((Arr::get($trace, 'file'), [
+            return !Str::startsWith((Arr::get($trace, 'file')), [
                 base_path() . '/vendor',
             ]);
         });


### PR DESCRIPTION
Remove str and arr global helpers for Laravel 6 support.

This is required if you want to work with Laravel 6, where string and array global helpers were replaced by a more OOP set of methods in Arr and Str classes.